### PR TITLE
Update Etna Client to set the logger upon initialisation

### DIFF
--- a/lib/etna/client.rb
+++ b/lib/etna/client.rb
@@ -4,13 +4,15 @@ module Etna
   class Client
     # This client is forcing all body request to be JSON format then qualify itself a JSON client
     # beside all communication with this API is JSON by default
-    def initialize(base_url)
+    def initialize(base_url, logger: nil, timeout: 60)
       @base_url = base_url
+      @logger = logger
+      @timeout = timeout
     end
 
     def execute(method_name, url, body = {}, options = {}, headers = {})
-      request = Components::Request.new(headers: headers)
-      request.build(method: method_name, url: @base_url + url, body: body.to_json, options: options, headers: headers)
+      request = Components::Request.new(headers: headers, logger: @logger, timeout: @timeout)
+      request.build(method: method_name, url: @base_url + url, body: body.to_json, options: options)
 
       request = before_request(request)
 

--- a/spec/etna/concenrs/logger_spec.rb
+++ b/spec/etna/concenrs/logger_spec.rb
@@ -3,19 +3,17 @@
 require 'spec_helper'
 
 module Etna
-  class TestingClient
+  class TestingClient < Etna::Client
     include Etna::Concerns::Logger
 
-    def initialize(base_url)
-      @base_url = base_url
-    end
+    
   end
 
   RSpec.describe Concerns::Logger do
     include_context 'Typhoeus responses'
 
     let(:logger) { ::Logger.new(IO::NULL) }
-    let(:client) { TestingClient.new('http://www.example.com') }
+    let(:client) { TestingClient.new('http://www.example.com', logger: logger) }
     let(:collection) { Components::Response.new(valid_collection_response, example_request).process }
     let(:entity) { Components::Response.new(valid_entity_response, example_request).process }
     let(:error) { Components::Response.new(invalid_json_response, example_request).process }
@@ -46,6 +44,11 @@ module Etna
       expect(log).to have_key(:server_response)
       expect(log).to have_key(:status)
       expect(log).to have_key(:code)
+    end
+
+    it 'sends the information to the logger' do 
+      expect(logger).to receive(:info).with(any_args)
+      client.send(:log, error, person_info)
     end
   end
 end


### PR DESCRIPTION
Add the logger as default parameter upon Client initialisation instance.