### PR TITLE
Explicitly require Forwardable on Etna client.

### DIFF
--- a/lib/etna.rb
+++ b/lib/etna.rb
@@ -2,6 +2,7 @@ require "etna/version"
 require "typhoeus"
 require 'json'
 require 'securerandom'
+require 'forwardable'
 
 ROOT_PATH = File.dirname(__FILE__)
 Dir.glob(ROOT_PATH + '/etna/concerns/*.rb') { |file| require file }


### PR DESCRIPTION
Ass discovered on Issue 3 there is missing require of
forwardable ruby library during this gem initialisation.

Solving [Issue 3](https://github.com/solarisBank/etna/issues/3)
