### PR TITLE
Refactor the library to respond with an standard interface

### DIFF
--- a/lib/etna.rb
+++ b/lib/etna.rb
@@ -6,4 +6,5 @@ require 'forwardable'
 
 ROOT_PATH = File.dirname(__FILE__)
 Dir.glob(ROOT_PATH + '/etna/concerns/*.rb') { |file| require file }
+Dir.glob(ROOT_PATH + '/etna/components/responses/base.rb') { |file| require file }
 Dir.glob(ROOT_PATH + '/etna/**/*.rb') { |file| require file }

--- a/lib/etna/components/errors/base.rb
+++ b/lib/etna/components/errors/base.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Etna
+  module Components
+    module Errors
+      class Base < Etna::Components::Responses::Base
+        attr_reader :message
+
+        def initialize(typhoeus_response, request, message = nil)
+          @response = typhoeus_response
+          @request = request
+          @message = message || "There was an error on the API: #{@response.return_code}"
+        end
+      end
+    end
+  end
+end

--- a/lib/etna/components/errors/errors.rb
+++ b/lib/etna/components/errors/errors.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Etna
+  module Components
+    module Errors
+      # rubocop:disable Style/CommentedKeyword
+      class ApiConnection < Base; end           # 0
+      class ApiRedirection < Base; end          # 301, 302, 303, 307
+      class ApiBadRequest < Base; end           # 400
+      class ApiUnauthorized < Base; end         # 401
+      class ApiInvalidPartnerCredentials < Base; end # 401 When Partner is not valid to get a new token
+      class ApiForbidden < Base; end            # 403
+      class ApiNotFound < Base; end             # 404
+      class ApiMethodNotAllowed < Base; end     # 405
+      class ApiResourceConflict < Base; end     # 409
+      class ApiUnprocessableEntity < Base; end  # 422
+      class ApiClient < Base; end               # 400..499
+      class ApiServer < Base; end               # 500..599
+      class ApiTimeout < Base; end              # timeout
+      # rubocop:enable Style/CommentedKeyword
+    end
+  end
+end

--- a/lib/etna/components/responder.rb
+++ b/lib/etna/components/responder.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Etna
+  module Components
+    # Converts a Typhoeus::Response into an Api::Responses::X kind of response
+    class Responder
+
+      def self.factor(typhoeus_response, request)
+        factor_error(typhoeus_response, request) || Etna::Components::Responses::Base.new(typhoeus_response, request)
+      end
+
+      private
+
+      # rubocop:disable Metrics/CyclomaticComplexity
+      def self.factor_error(typhoeus_response, request)
+        case typhoeus_response.code
+        when 0
+          Errors::ApiTimeout.new(typhoeus_response, request, "Request timed out in #{@response.total_time}")
+        when 300, 301, 302, 303, 307
+          Errors::ApiRedirection.new(typhoeus_response, request)
+        when 400
+          Errors::ApiBadRequest.new(typhoeus_response, request)
+        when 403
+          Errors::ApiForbidden.new(typhoeus_response, request)
+        when 404
+          Errors::ApiNotFound.new(typhoeus_response, request, 'Not found')
+        when 405
+          Errors::ApiMethodNotAllowed.new(typhoeus_response, request)
+        when 409
+          Errors::ApiResourceConflict.new(typhoeus_response, request)
+        when 422
+          Errors::ApiUnprocessableEntity.new(typhoeus_response, request)
+        when 423..499
+          Errors::ApiClient.new(typhoeus_response, request)
+        when 500..599
+          Errors::ApiServer.new(typhoeus_response, request)
+        end
+      end
+      # rubocop:enable Metrics/CyclomaticComplexity
+    end
+  end
+end

--- a/lib/etna/components/response.rb
+++ b/lib/etna/components/response.rb
@@ -64,7 +64,11 @@ module Etna
       end
 
       def parse_body!
-        response.body.empty? ? {} : JSON.parse(response.body)
+        if response.headers["Content-Type"].match(/json/)
+          response.body.empty? ? {} : JSON.parse(response.body)
+        else
+          response.body
+        end
       rescue ::JSON::ParserError => exception
         Responses::ApiJsonParseError.new(exception, self)
       end

--- a/lib/etna/components/responses/base.rb
+++ b/lib/etna/components/responses/base.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module Etna
+  module Components
+    module Responses
+      class Base
+        extend Forwardable
+
+        attr_reader :response, :error, :body, :request, :exception, :response_data
+
+        def_delegators :@response, *(Typhoeus::Response.instance_methods - Object.instance_methods - %i[body request status code])
+
+        def initialize(typhoeus_response, request)
+          @response = typhoeus_response
+          @request = request
+        end
+
+        def status
+          @response.code
+        end
+
+        def code
+          @response.return_code
+        end
+
+        def error?
+          !success?
+        end
+
+        def type
+          if response.headers["Content-Type"].match(/json/)
+            :json
+          elsif response.headers["Content-Type"].match(/html/)
+            :html
+          else
+            :text
+          end
+        end
+
+        def to_h
+          {
+            status: status,
+            code: code,
+            body: body,
+            type: type,
+            total_time: total_time
+          }
+        end
+      end
+    end
+  end
+end

--- a/spec/etna/components/responder_spec.rb
+++ b/spec/etna/components/responder_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module Etna
+  # Converts a Typhoeus::Response into an Api::Components::Responses::X kind of response
+  RSpec.describe Components::Responder do
+    include_context 'Typhoeus responses'
+    subject { Components::Responder }
+
+    context "#factor" do
+      it 'returns a proper error if the Typhoeus response is an error' do
+        subject.factor(non_valid_api_response, example_request).tap do |response|
+          expect(response).to be_a(Etna::Components::Responses::Base)
+          expect(response.status).to eq(404)
+          expect(response.code).to eq(:ok)
+          expect(response.message).to eq("Not found")
+
+          expect(response).to be_error
+          expect(response).not_to be_success
+        end
+      end
+
+      it "returns a json response if the Typhoeus is a valid response" do
+        subject.factor(valid_collection_response, example_request).tap do |response|
+          expect(response).to be_a(Etna::Components::Responses::Base)
+          expect(response.status).to eq(200)
+          expect(response.code).to eq(:ok)
+
+          expect(response).not_to be_error
+          expect(response).to be_success
+        end
+      end
+    end
+  end
+end

--- a/spec/etna/components/responses/base_spec.rb
+++ b/spec/etna/components/responses/base_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+module Etna
+  RSpec.describe Components::Responses::Base do
+    include_context 'Typhoeus responses'
+
+    subject { Components::Responses::Base.new(valid_collection_response, example_request) }
+
+    context '#to_h' do
+      it 'returns a hash with the status, title, details and body of the response' do
+        subject.to_h.tap do |h|
+          expect(h[:status]).to eq(200)
+          expect(h[:code]).to eq(:ok)
+          expect(h[:body]).to eq(subject.body)
+          expect(h[:type]).to eq(:json)
+          expect(h[:total_time]).not_to be_nil
+        end
+      end
+    end
+
+    context '#success?' do
+      it 'sign the object as a success object' do
+        expect(subject).to be_success
+        expect(subject).not_to be_error
+      end
+    end
+
+    context '#type' do
+      it 'returns the response content type' do
+        expect(subject.type).to eq(:json)
+      end
+    end
+  end
+end


### PR DESCRIPTION
- [x] Abstract the response object into its own base class
- [] Move errors to its own component to differentiate HTTP errors from valid errors from the API
- [] Create an HTTP response class for those API's that responds with HTTP instead of JSON
- [] Make a clearer JSON Response class to encapsulate the API response